### PR TITLE
Add @eslint/js and fix lint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react-router-dom": "^6.22.3"
       },
       "devDependencies": {
+        "@eslint/js": "^8.57.1",
         "@types/react": "^18.2.56",
         "@types/react-dom": "^18.2.19",
         "@vitejs/plugin-react": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
+    "lint": "eslint . --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -27,6 +27,7 @@
     "@vitejs/plugin-react": "^4.2.1",
     "autoprefixer": "^10.4.18",
     "eslint": "^8.56.0",
+    "@eslint/js": "^8.57.1",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.5",

--- a/src/components/reports/PDFGenerator.jsx
+++ b/src/components/reports/PDFGenerator.jsx
@@ -4,7 +4,7 @@ import SafeIcon from '../../common/SafeIcon';
 import * as FiIcons from 'react-icons/fi';
 import { jsPDF } from 'jspdf';
 
-const { FiFileText, FiDownload, FiX, FiSettings, FiUser, FiBarChart3, FiTrendingUp, FiDollarSign } = FiIcons;
+const { FiFileText, FiDownload, FiX, FiSettings, FiUser, FiBarChart3, FiTrendingUp, FiDollarSign, FiPieChart } = FiIcons;
 
 const PDFGenerator = ({ onClose }) => {
   // Get evaluations from localStorage


### PR DESCRIPTION
## Summary
- add `@eslint/js` to devDependencies
- drop deprecated ESLint `--ext` flag
- import `FiPieChart` icon for PDF generation
- run `npm install`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687062c641008333844ac4586b6565d4